### PR TITLE
ptywrap: sync secretty's cwd to the child via OSC 7

### DIFF
--- a/internal/ptywrap/cwdsync.go
+++ b/internal/ptywrap/cwdsync.go
@@ -1,0 +1,133 @@
+package ptywrap
+
+import (
+	"bytes"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/suryansh-23/secretty/internal/debug"
+)
+
+// OSC 7 working-directory report markers.
+var (
+	osc7Prefix = []byte("\x1b]7;") // ESC ] 7 ;
+	oscST      = []byte("\x1b\\")  // String Terminator (ESC \)
+)
+
+// cwdWatchMaxBuffer caps the partial-sequence buffer so a stream that never
+// contains a terminator can't grow memory without bound.
+const cwdWatchMaxBuffer = 1 << 16 // 64 KiB
+
+// cwdSyncDisabled reports whether OSC 7 cwd syncing has been turned off via env.
+func cwdSyncDisabled() bool {
+	v := os.Getenv("SECRETTY_DISABLE_CWD_SYNC")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+// newCwdSyncObserver returns an output observer that watches the child's output
+// stream for OSC 7 working-directory reports — ESC ] 7 ; file://host/path (BEL|ST)
+// — and chdir()s the secretty process to the reported directory.
+//
+// Why: secretty runs the shell under its own PTY and proxies IO, so secretty is
+// the process a parent terminal or multiplexer reads the working directory FROM.
+// secretty never changes its own cwd, so it stays at its launch directory forever
+// and the parent always sees a stale dir. Inside tmux in particular this means
+// #{pane_current_path} is frozen (usually /), which breaks new-window -c, the
+// automatic window name, and tmux-resurrect's saved cwd. Following the child's
+// OSC 7 reports keeps secretty's cwd in sync so the parent sees the truth.
+//
+// The observer only READS the stream (it never mutates bytes), consistent with
+// secretty's ANSI no-mutation invariant. It requires the shell to emit OSC 7,
+// which most modern shell integrations / prompts already do (zsh: add-zsh-hook
+// chpwd; bash: PROMPT_COMMAND). Disable via SECRETTY_DISABLE_CWD_SYNC=1.
+//
+// The returned closure is invoked from a single goroutine (the output copy loop),
+// so it needs no synchronization. os.Chdir is process-global; secretty loads its
+// config before the child starts, so changing cwd mid-session is safe.
+func newCwdSyncObserver(logger *debug.Logger) func([]byte) {
+	var buf []byte
+	last := ""
+	return func(p []byte) {
+		buf = append(buf, p...)
+		if len(buf) > cwdWatchMaxBuffer {
+			buf = buf[len(buf)-cwdWatchMaxBuffer:]
+		}
+		for {
+			start := bytes.Index(buf, osc7Prefix)
+			if start < 0 {
+				// No prefix yet; retain only a short tail in case a prefix is
+				// split across reads.
+				if keep := len(osc7Prefix) - 1; len(buf) > keep {
+					buf = append(buf[:0], buf[len(buf)-keep:]...)
+				}
+				return
+			}
+			rest := buf[start+len(osc7Prefix):]
+			term, termLen := oscTerminator(rest)
+			if term < 0 {
+				// Incomplete sequence; keep from the prefix and wait for more.
+				buf = append(buf[:0], buf[start:]...)
+				return
+			}
+			if dir := parseOSC7Path(string(rest[:term])); dir != "" && dir != last {
+				if err := os.Chdir(dir); err == nil {
+					last = dir
+					if logger != nil {
+						logger.Infof("ptywrap: cwd_sync dir=%s", dir)
+					}
+				} else if logger != nil {
+					logger.Infof("ptywrap: cwd_sync_chdir_failed dir=%s err=%v", dir, err)
+				}
+			}
+			buf = append(buf[:0], rest[term+termLen:]...)
+		}
+	}
+}
+
+// oscTerminator returns the index and length of the earliest OSC terminator
+// (BEL 0x07, or ST = ESC \) in b, or (-1, 0) if none is present yet.
+func oscTerminator(b []byte) (int, int) {
+	bel := bytes.IndexByte(b, 0x07)
+	st := bytes.Index(b, oscST)
+	switch {
+	case bel < 0 && st < 0:
+		return -1, 0
+	case bel < 0:
+		return st, len(oscST)
+	case st < 0:
+		return bel, 1
+	case bel < st:
+		return bel, 1
+	default:
+		return st, len(oscST)
+	}
+}
+
+// parseOSC7Path extracts a filesystem path from an OSC 7 payload, conventionally
+// "file://host/path" (path may be percent-encoded), tolerating a bare path too.
+// Returns "" when nothing usable is found.
+func parseOSC7Path(payload string) string {
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		return ""
+	}
+	if strings.HasPrefix(payload, "file://") {
+		if u, err := url.Parse(payload); err == nil && u.Path != "" {
+			return u.Path
+		}
+		// Fallback: strip scheme+authority, unescape the remaining path.
+		rest := strings.TrimPrefix(payload, "file://")
+		if i := strings.IndexByte(rest, '/'); i >= 0 {
+			if p, err := url.PathUnescape(rest[i:]); err == nil {
+				return p
+			}
+			return rest[i:]
+		}
+		return ""
+	}
+	if strings.HasPrefix(payload, "/") {
+		return payload
+	}
+	return ""
+}

--- a/internal/ptywrap/cwdsync_test.go
+++ b/internal/ptywrap/cwdsync_test.go
@@ -1,0 +1,81 @@
+package ptywrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseOSC7Path(t *testing.T) {
+	cases := map[string]string{
+		"file://host/Users/me/proj":  "/Users/me/proj",
+		"file:///Users/me/proj":      "/Users/me/proj",
+		"file://host/Users/me/a%20b": "/Users/me/a b",
+		"/bare/path":                 "/bare/path",
+		"":                           "",
+		"file://host":                "",
+		"notaurl":                    "",
+	}
+	for in, want := range cases {
+		if got := parseOSC7Path(in); got != want {
+			t.Errorf("parseOSC7Path(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestOSCTerminator(t *testing.T) {
+	if i, n := oscTerminator([]byte("abc\x07def")); i != 3 || n != 1 {
+		t.Errorf("BEL: got (%d,%d), want (3,1)", i, n)
+	}
+	if i, n := oscTerminator([]byte("abc\x1b\\def")); i != 3 || n != 2 {
+		t.Errorf("ST: got (%d,%d), want (3,2)", i, n)
+	}
+	if i, n := oscTerminator([]byte("\x07\x1b\\")); i != 0 || n != 1 {
+		t.Errorf("earliest: got (%d,%d), want (0,1)", i, n)
+	}
+	if i, n := oscTerminator([]byte("no terminator")); i != -1 || n != 0 {
+		t.Errorf("none: got (%d,%d), want (-1,0)", i, n)
+	}
+}
+
+func TestCwdSyncObserverChdir(t *testing.T) {
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	obs := newCwdSyncObserver(nil)
+
+	// BEL-terminated, single chunk, surrounded by other output.
+	obs([]byte("hello\x1b]7;file://host" + dir + "\x07world"))
+	assertSameDir(t, dir)
+
+	// ST-terminated sequence split across two observer calls.
+	if err := os.Chdir(orig); err != nil {
+		t.Fatal(err)
+	}
+	seq := "\x1b]7;file://host" + sub + "\x1b\\"
+	obs([]byte(seq[:9]))
+	obs([]byte(seq[9:]))
+	assertSameDir(t, sub)
+}
+
+func assertSameDir(t *testing.T, want string) {
+	t.Helper()
+	got, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gi, err1 := os.Stat(got)
+	wi, err2 := os.Stat(want)
+	if err1 != nil || err2 != nil || !os.SameFile(gi, wi) {
+		t.Errorf("cwd = %q, want %q (stat errs: %v, %v)", got, want, err1, err2)
+	}
+}

--- a/internal/ptywrap/ptywrap.go
+++ b/internal/ptywrap/ptywrap.go
@@ -24,10 +24,11 @@ const copyDrainTimeout = 750 * time.Millisecond
 
 // Options controls PTY execution behavior.
 type Options struct {
-	RawMode       bool
-	Output        io.Writer
-	Logger        *debug.Logger
-	InputObserver func([]byte)
+	RawMode        bool
+	Output         io.Writer
+	Logger         *debug.Logger
+	InputObserver  func([]byte)
+	OutputObserver func([]byte)
 }
 
 // RunCommand starts cmd under a PTY and proxies IO.
@@ -75,8 +76,25 @@ func RunCommand(ctx context.Context, cmd *exec.Cmd, opts Options) (int, error) {
 	defer cancel()
 
 	errCh := make(chan error, 1)
+	// Observe the child's output for OSC 7 cwd reports and keep secretty's own
+	// working directory in sync, so parent terminals/multiplexers (e.g. tmux) see
+	// the child's real cwd instead of secretty's frozen launch dir. Composes with
+	// any caller-supplied OutputObserver.
+	outObserver := opts.OutputObserver
+	if !cwdSyncDisabled() {
+		cwdObserver := newCwdSyncObserver(opts.Logger)
+		if outObserver == nil {
+			outObserver = cwdObserver
+		} else {
+			userObserver := outObserver
+			outObserver = func(b []byte) {
+				userObserver(b)
+				cwdObserver(b)
+			}
+		}
+	}
 	go copyInput(ctx, ptmx, os.Stdin, opts.Logger, opts.InputObserver)
-	go copyWithContext(ctx, out, ptmx, errCh)
+	go copyWithContext(ctx, out, ptmx, errCh, outObserver)
 
 	waitErr := cmd.Wait()
 	cancel()
@@ -257,11 +275,37 @@ func setEnv(env []string, key, value string) []string {
 	return append(env, key+"="+value)
 }
 
-func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader, errCh chan<- error) {
-	_, err := io.Copy(dst, src)
-	select {
-	case errCh <- err:
-	case <-ctx.Done():
+func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader, errCh chan<- error, observer func([]byte)) {
+	if observer == nil {
+		_, err := io.Copy(dst, src)
+		select {
+		case errCh <- err:
+		case <-ctx.Done():
+		}
+		return
+	}
+	// Manual copy so we can hand each chunk to the observer (e.g. OSC 7 cwd sync)
+	// before forwarding it downstream. The observer must not mutate the bytes.
+	buf := make([]byte, 32*1024)
+	for {
+		n, rerr := src.Read(buf)
+		if n > 0 {
+			observer(buf[:n])
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				select {
+				case errCh <- werr:
+				case <-ctx.Done():
+				}
+				return
+			}
+		}
+		if rerr != nil {
+			select {
+			case errCh <- rerr:
+			case <-ctx.Done():
+			}
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem
secretty runs the shell under its own PTY and proxies IO, so **secretty** is the process a parent terminal / multiplexer reads the working directory *from*. It never changes its own cwd, so it stays at its launch directory forever and the parent always sees a stale dir.

Inside **tmux** this is especially painful: `#{pane_current_path}` is frozen (usually `/`), which breaks `new-window -c "#{pane_current_path}"`, the automatic window name, and `tmux-resurrect`'s saved cwd (sessions restore in `/`). It also makes shell-integration cwd features (terminal titles, "new tab here") wrong.

## Fix
Add a **read-only OSC 7 observer** on the child's output stream. When the child emits `ESC ] 7 ; file://host/path (BEL|ST)` — the standard cwd report most shell integrations/prompts already send — secretty `os.Chdir()`s to match. The parent then reads the correct cwd from secretty's process for free.

- Observer **only reads** the stream, never mutates bytes — consistent with the "never mutate ANSI escape sequences" invariant.
- Default-on; opt out with `SECRETTY_DISABLE_CWD_SYNC=1`.
- Handles BEL and ST terminators and sequences split across reads; caps its buffer at 64 KiB.

## Files
- `internal/ptywrap/cwdsync.go` — OSC 7 scanner + path parser + chdir-on-change.
- `internal/ptywrap/ptywrap.go` — add `Options.OutputObserver`, route output through it, install the cwd-sync observer in `RunCommand`.
- `internal/ptywrap/cwdsync_test.go` — unit tests for parser, terminator scan, and chdir behavior.

## Testing
- `go test ./internal/ptywrap/` passes (existing + new).
- Manual: `secretty run -- bash -c 'printf "\033]7;file://h/private/tmp\007"; sleep 4'` → secretty's cwd becomes `/private/tmp`; with `SECRETTY_DISABLE_CWD_SYNC=1` it stays at the launch dir.

Requires the shell to emit OSC 7 (zsh: `add-zsh-hook chpwd`; bash: `PROMPT_COMMAND`; Ghostty/iTerm/VTE shell-integration already do). Happy to gate it behind a config option instead of an env var if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)